### PR TITLE
Hotfix/ 32 Resolver problemas dos testes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,5 @@ Rails.application.routes.draw do
   root "home#index"
 
   mount Sidekiq::Web => "/sidekiq"
-  mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
Após adicionar o devise e as novas gems os testes quebraram.

Problema identificado foi que no arquivo routes.rb o LetterOpenerWeb::Engine não foi definido para ser montado apenas em desenvolvimento.

Resolver foi simples. Somente definir que a montagem do LetterOpenerWeb::Engine deve ser apenas em desenvolvimento